### PR TITLE
Add Laravel Scout and Algolia explanation to search.md

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -29,6 +29,36 @@ By default, when displaying search results, Runway will use the first listable c
 ],
 ```
 
+### Working in sync with Laravel Scout and Algolia
+
+In some use cases, you might already work with Laravel Scout and Algolia for some of your models. 
+
+For example: You might have an E-shop which generates orders, and you use Laravel Scout in areas completely outside of the scope of Statamic (frontend or backend). But on the other hand, you do have a listing of those orders in Statamic just to make tiny changes or use Statamic Actions on some of those orders.
+
+To keep your search index in sync, make sure to use the following code in your model:
+
+```php
+public function getScoutKey(): mixed
+{
+    return 'runway::order::' . $this->id;
+}
+```
+
+Also make sure to have all the fields you want to be searchable in Statamic also in your "searchable array", for example like this:
+
+```php
+public function toSearchableArray()
+{
+    return [
+        'id' => $this->id,
+        'order_number' => $this->order_number,
+        'customer_name' => $this->customer->full_name,
+        'customer_email' => $this->customer->email,
+        'article_string' => $this->articles->pluck('title')->implode(' '),
+    ];
+}
+```
+
 ## Further documentation...
 
 For further documentation on integrating Search in your site, please review the [Statamic Documentation](https://statamic.dev/search#overview).


### PR DESCRIPTION
I got bitten a bit by trying to use Laravel Scout in parallel with the Statamic and Runway search indexes. This addition to the docs explains what I had to do make it work.